### PR TITLE
Add training suitability extension stats

### DIFF
--- a/code/segmentation/engine/src/core/TrainingSuitability.cpp
+++ b/code/segmentation/engine/src/core/TrainingSuitability.cpp
@@ -1,0 +1,47 @@
+#include "TrainingSuitability.hpp"
+#include <unordered_map>
+#include <numeric>
+#include <algorithm>
+#include <cmath>
+#include <string>
+
+using std::string;
+using std::vector;
+using std::unordered_map;
+
+nlohmann::json extension_stats(const vector<DataPoint> &segment) {
+  unordered_map<string, vector<double>> buckets;
+  for (const auto &dp : segment) {
+    if (!dp.extensions.is_object())
+      continue;
+    for (auto it = dp.extensions.begin(); it != dp.extensions.end(); ++it) {
+      if (it->is_number()) {
+        buckets[it.key()].push_back(it->get<double>());
+      }
+    }
+  }
+
+  nlohmann::json result = nlohmann::json::object();
+  for (auto &kv : buckets) {
+    const auto &vals = kv.second;
+    if (vals.empty())
+      continue;
+    double sum = std::accumulate(vals.begin(), vals.end(), 0.0);
+    double mean = sum / vals.size();
+    double min = *std::min_element(vals.begin(), vals.end());
+    double max = *std::max_element(vals.begin(), vals.end());
+    double sq = 0.0;
+    for (double v : vals) {
+      double d = v - mean;
+      sq += d * d;
+    }
+    double stddev = std::sqrt(sq / vals.size());
+    result[kv.first] = {{"count", vals.size()},
+                        {"mean", mean},
+                        {"std", stddev},
+                        {"min", min},
+                        {"max", max}};
+  }
+  return result;
+}
+

--- a/code/segmentation/engine/src/core/TrainingSuitability.cpp
+++ b/code/segmentation/engine/src/core/TrainingSuitability.cpp
@@ -9,7 +9,7 @@ using std::string;
 using std::vector;
 using std::unordered_map;
 
-nlohmann::json extension_stats(const vector<DataPoint> &segment) {
+TrainingSuitabilityScore compute_tss(const vector<DataPoint> &segment) {
   unordered_map<string, vector<double>> buckets;
   for (const auto &dp : segment) {
     if (!dp.extensions.is_object())
@@ -21,7 +21,7 @@ nlohmann::json extension_stats(const vector<DataPoint> &segment) {
     }
   }
 
-  nlohmann::json result = nlohmann::json::object();
+  TrainingSuitabilityScore tss;
   for (auto &kv : buckets) {
     const auto &vals = kv.second;
     if (vals.empty())
@@ -36,12 +36,9 @@ nlohmann::json extension_stats(const vector<DataPoint> &segment) {
       sq += d * d;
     }
     double stddev = std::sqrt(sq / vals.size());
-    result[kv.first] = {{"count", vals.size()},
-                        {"mean", mean},
-                        {"std", stddev},
-                        {"min", min},
-                        {"max", max}};
+    tss.extensions[kv.first] = {vals.size(), mean, stddev, min, max};
   }
-  return result;
+
+  return tss;
 }
 

--- a/code/segmentation/engine/src/core/TrainingSuitability.hpp
+++ b/code/segmentation/engine/src/core/TrainingSuitability.hpp
@@ -1,0 +1,10 @@
+#pragma once
+#include "models/CoreTypes.hpp"
+#include <nlohmann/json.hpp>
+#include <vector>
+
+// Compute basic statistics for each numeric extension key present in a segment.
+// The result is a JSON object mapping extension names to their statistics
+// (count, mean, std, min, max).
+nlohmann::json extension_stats(const std::vector<DataPoint> &segment);
+

--- a/code/segmentation/engine/src/core/TrainingSuitability.hpp
+++ b/code/segmentation/engine/src/core/TrainingSuitability.hpp
@@ -1,10 +1,24 @@
 #pragma once
 #include "models/CoreTypes.hpp"
-#include <nlohmann/json.hpp>
+#include <cstddef>
+#include <unordered_map>
 #include <vector>
+#include <string>
 
-// Compute basic statistics for each numeric extension key present in a segment.
-// The result is a JSON object mapping extension names to their statistics
-// (count, mean, std, min, max).
-nlohmann::json extension_stats(const std::vector<DataPoint> &segment);
+// Basic statistics derived from numeric extension values.
+struct ExtensionStats {
+  std::size_t count{0};
+  double mean{0.0};
+  double std{0.0};
+  double min{0.0};
+  double max{0.0};
+};
+
+// Training suitability score for a segment, keyed by extension name.
+struct TrainingSuitabilityScore {
+  std::unordered_map<std::string, ExtensionStats> extensions;
+};
+
+// Compute a TrainingSuitabilityScore for the provided segment's extension values.
+TrainingSuitabilityScore compute_tss(const std::vector<DataPoint> &segment);
 


### PR DESCRIPTION
## Summary
- add TrainingSuitability utility to compute basic statistics for numeric segment extensions

## Testing
- `cmake ..`
- `make -j2` *(fails: fatal error: mysql/mysql.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6a311ba0832db56bb071a9e7d09e