### PR TITLE
Add training suitability extension stats

### DIFF
--- a/code/segmentation/engine/config/settings.json
+++ b/code/segmentation/engine/config/settings.json
@@ -12,7 +12,9 @@
       "/view",
       "/viewLab",
       "/lab/meta",
-      "/segments"
+      "/segments",
+      "/segment",
+      "/tss"
     ]
   },
   "segmentation": {

--- a/code/segmentation/engine/src/core/TrainingSuitability.cpp
+++ b/code/segmentation/engine/src/core/TrainingSuitability.cpp
@@ -1,0 +1,44 @@
+#include "TrainingSuitability.hpp"
+#include <unordered_map>
+#include <numeric>
+#include <algorithm>
+#include <cmath>
+#include <string>
+
+using std::string;
+using std::vector;
+using std::unordered_map;
+
+TrainingSuitabilityScore compute_tss(const vector<DataPoint> &segment) {
+  unordered_map<string, vector<double>> buckets;
+  for (const auto &dp : segment) {
+    if (!dp.extensions.is_object())
+      continue;
+    for (auto it = dp.extensions.begin(); it != dp.extensions.end(); ++it) {
+      if (it->is_number()) {
+        buckets[it.key()].push_back(it->get<double>());
+      }
+    }
+  }
+
+  TrainingSuitabilityScore tss;
+  for (auto &kv : buckets) {
+    const auto &vals = kv.second;
+    if (vals.empty())
+      continue;
+    double sum = std::accumulate(vals.begin(), vals.end(), 0.0);
+    double mean = sum / vals.size();
+    double min = *std::min_element(vals.begin(), vals.end());
+    double max = *std::max_element(vals.begin(), vals.end());
+    double sq = 0.0;
+    for (double v : vals) {
+      double d = v - mean;
+      sq += d * d;
+    }
+    double stddev = std::sqrt(sq / vals.size());
+    tss.extensions[kv.first] = {vals.size(), mean, stddev, min, max};
+  }
+
+  return tss;
+}
+

--- a/code/segmentation/engine/src/core/TrainingSuitability.hpp
+++ b/code/segmentation/engine/src/core/TrainingSuitability.hpp
@@ -1,0 +1,24 @@
+#pragma once
+#include "models/CoreTypes.hpp"
+#include <cstddef>
+#include <unordered_map>
+#include <vector>
+#include <string>
+
+// Basic statistics derived from numeric extension values.
+struct ExtensionStats {
+  std::size_t count{0};
+  double mean{0.0};
+  double std{0.0};
+  double min{0.0};
+  double max{0.0};
+};
+
+// Training suitability score for a segment, keyed by extension name.
+struct TrainingSuitabilityScore {
+  std::unordered_map<std::string, ExtensionStats> extensions;
+};
+
+// Compute a TrainingSuitabilityScore for the provided segment's extension values.
+TrainingSuitabilityScore compute_tss(const std::vector<DataPoint> &segment);
+

--- a/code/segmentation/engine/src/http/http_handler.cpp
+++ b/code/segmentation/engine/src/http/http_handler.cpp
@@ -1,6 +1,7 @@
 #include "http_handler.hpp"
 
 #include "core/RouteSignalBuilder.hpp"
+#include "core/TrainingSuitability.hpp"
 #include "core/wavelets/WaveletFootprint.hpp"
 #include "httplib.h"
 #include "infra/MySQLSegmentDB.hpp"
@@ -66,7 +67,9 @@ void HttpHandler::callGetHandler(std::string action,
       {"view", &HttpHandler::handleView},
       {"viewLab", &HttpHandler::handleSignalLabUI},
       {"lab/meta", &HttpHandler::handleLabMeta},
-      {"segments", &HttpHandler::handleSegments}};
+      {"segments", &HttpHandler::handleSegments},
+      {"segment", &HttpHandler::handleSegment},
+      {"tss", &HttpHandler::handleTss}};
 
   if (auto it = kGetHandlers.find(action); it != kGetHandlers.end()) {
     (this->*(it->second))(req, res);
@@ -1016,4 +1019,282 @@ void HttpHandler::handleSegments(const httplib::Request &req,
   // 5) Return the GeoJSON
   res.set_header("Access-Control-Allow-Origin", "*");
   res.set_content(fc.dump(), "application/json");
+}
+
+void HttpHandler::handleSegment(const httplib::Request &req,
+                                httplib::Response &res) {
+  if (!req.has_param("uid")) {
+    res.status = 400;
+    res.set_content(R"({"error":"missing uid"})", "application/json");
+    return;
+  }
+
+  std::string uid_hex = req.get_param_value("uid");
+
+  static const std::string sql = R"(
+    SELECT direction,length_m,kind,coords_json
+    FROM segment_defs WHERE segment_uid = UNHEX(?) LIMIT 1;
+  )";
+
+  if (!db_) {
+    res.status = 500;
+    res.set_content(R"({"error":"internal db connection not initialized"})",
+                    "application/json");
+    return;
+  }
+
+  MYSQL_STMT *stmt = mysql_stmt_init(db_);
+  if (!stmt) {
+    res.status = 500;
+    res.set_content(R"({"error":"db statement init failed"})",
+                    "application/json");
+    return;
+  }
+  if (mysql_stmt_prepare(stmt, sql.c_str(),
+                         static_cast<unsigned long>(sql.size())) != 0) {
+    std::string e = mysql_error(db_);
+    mysql_stmt_close(stmt);
+    res.status = 500;
+    res.set_content(std::string(R"({"error":"prepare failed: )") + e + "\"}",
+                    "application/json");
+    return;
+  }
+
+  MYSQL_BIND pbind[1];
+  memset(pbind, 0, sizeof(pbind));
+  unsigned long uid_len = uid_hex.size();
+  pbind[0].buffer_type = MYSQL_TYPE_STRING;
+  pbind[0].buffer = uid_hex.data();
+  pbind[0].buffer_length = uid_len;
+  pbind[0].length = &uid_len;
+
+  if (mysql_stmt_bind_param(stmt, pbind) != 0) {
+    std::string e = mysql_error(db_);
+    mysql_stmt_close(stmt);
+    res.status = 500;
+    res.set_content(std::string(R"({"error":"bind params failed: )") + e +
+                        "\"}",
+                    "application/json");
+    return;
+  }
+
+  if (mysql_stmt_execute(stmt) != 0) {
+    std::string e = mysql_error(db_);
+    mysql_stmt_close(stmt);
+    res.status = 500;
+    res.set_content(std::string(R"({"error":"execute failed: )") + e + "\"}",
+                    "application/json");
+    return;
+  }
+
+  MYSQL_BIND rbind[4];
+  memset(rbind, 0, sizeof(rbind));
+  char dir_buf[8];
+  unsigned long dir_len = 0;
+  double length_m = 0;
+  unsigned char kind_val = 0;
+  std::vector<char> json_buf(1 << 16);
+  unsigned long json_len = 0;
+
+  rbind[0].buffer_type = MYSQL_TYPE_STRING;
+  rbind[0].buffer = dir_buf;
+  rbind[0].buffer_length = sizeof(dir_buf);
+  rbind[0].length = &dir_len;
+
+  rbind[1].buffer_type = MYSQL_TYPE_DOUBLE;
+  rbind[1].buffer = &length_m;
+
+  rbind[2].buffer_type = MYSQL_TYPE_TINY;
+  rbind[2].buffer = &kind_val;
+  rbind[2].is_unsigned = true;
+
+  rbind[3].buffer_type = MYSQL_TYPE_STRING;
+  rbind[3].buffer = json_buf.data();
+  rbind[3].buffer_length = json_buf.size();
+  rbind[3].length = &json_len;
+
+  if (mysql_stmt_bind_result(stmt, rbind) != 0 ||
+      mysql_stmt_store_result(stmt) != 0) {
+    std::string e = mysql_error(db_);
+    mysql_stmt_close(stmt);
+    res.status = 500;
+    res.set_content(std::string(R"({"error":"bind/store result failed: )") + e +
+                        "\"}",
+                    "application/json");
+    return;
+  }
+
+  int rc = mysql_stmt_fetch(stmt);
+  if (rc == MYSQL_NO_DATA) {
+    mysql_stmt_free_result(stmt);
+    mysql_stmt_close(stmt);
+    res.status = 404;
+    res.set_content(R"({"error":"not found"})", "application/json");
+    return;
+  }
+  if (rc == 1) {
+    std::string e = mysql_error(db_);
+    mysql_stmt_free_result(stmt);
+    mysql_stmt_close(stmt);
+    res.status = 500;
+    res.set_content(std::string(R"({"error":"fetch failed: )") + e + "\"}",
+                    "application/json");
+    return;
+  }
+
+  nlohmann::json out;
+  out["uid"] = uid_hex;
+  out["direction"] = std::string(dir_buf, dir_len);
+  out["length_m"] = length_m;
+  out["kind"] = static_cast<unsigned int>(kind_val);
+  out["coordinates"] =
+      nlohmann::json::parse(std::string(json_buf.data(), json_len));
+
+  mysql_stmt_free_result(stmt);
+  mysql_stmt_close(stmt);
+
+  res.set_header("Access-Control-Allow-Origin", "*");
+  res.set_content(out.dump(), "application/json");
+}
+
+void HttpHandler::handleTss(const httplib::Request &req,
+                            httplib::Response &res) {
+  if (!req.has_param("id")) {
+    res.status = 400;
+    res.set_content(R"({"error":"missing id"})", "application/json");
+    return;
+  }
+  long long seg_id = 0;
+  try {
+    seg_id = std::stoll(req.get_param_value("id"));
+  } catch (...) {
+    res.status = 400;
+    res.set_content(R"({"error":"invalid id"})", "application/json");
+    return;
+  }
+
+  static const std::string sql = R"(
+    SELECT sd.coords_json
+    FROM route_segments rs
+    JOIN segment_defs sd ON rs.segment_uid = sd.segment_uid
+    WHERE rs.segment_id = ? LIMIT 1;
+  )";
+
+  if (!db_) {
+    res.status = 500;
+    res.set_content(R"({"error":"internal db connection not initialized"})",
+                    "application/json");
+    return;
+  }
+
+  MYSQL_STMT *stmt = mysql_stmt_init(db_);
+  if (!stmt) {
+    res.status = 500;
+    res.set_content(R"({"error":"db statement init failed"})",
+                    "application/json");
+    return;
+  }
+  if (mysql_stmt_prepare(stmt, sql.c_str(),
+                         static_cast<unsigned long>(sql.size())) != 0) {
+    std::string e = mysql_error(db_);
+    mysql_stmt_close(stmt);
+    res.status = 500;
+    res.set_content(std::string(R"({"error":"prepare failed: )") + e + "\"}",
+                    "application/json");
+    return;
+  }
+
+  MYSQL_BIND pbind[1];
+  memset(pbind, 0, sizeof(pbind));
+  pbind[0].buffer_type = MYSQL_TYPE_LONGLONG;
+  pbind[0].buffer = &seg_id;
+
+  if (mysql_stmt_bind_param(stmt, pbind) != 0) {
+    std::string e = mysql_error(db_);
+    mysql_stmt_close(stmt);
+    res.status = 500;
+    res.set_content(std::string(R"({"error":"bind params failed: )") + e +
+                        "\"}",
+                    "application/json");
+    return;
+  }
+
+  if (mysql_stmt_execute(stmt) != 0) {
+    std::string e = mysql_error(db_);
+    mysql_stmt_close(stmt);
+    res.status = 500;
+    res.set_content(std::string(R"({"error":"execute failed: )") + e + "\"}",
+                    "application/json");
+    return;
+  }
+
+  MYSQL_BIND rbind[1];
+  memset(rbind, 0, sizeof(rbind));
+  std::vector<char> json_buf(1 << 16);
+  unsigned long json_len = 0;
+  rbind[0].buffer_type = MYSQL_TYPE_STRING;
+  rbind[0].buffer = json_buf.data();
+  rbind[0].buffer_length = json_buf.size();
+  rbind[0].length = &json_len;
+
+  if (mysql_stmt_bind_result(stmt, rbind) != 0 ||
+      mysql_stmt_store_result(stmt) != 0) {
+    std::string e = mysql_error(db_);
+    mysql_stmt_close(stmt);
+    res.status = 500;
+    res.set_content(std::string(R"({"error":"bind/store result failed: )") + e +
+                        "\"}",
+                    "application/json");
+    return;
+  }
+
+  int rc = mysql_stmt_fetch(stmt);
+  if (rc == MYSQL_NO_DATA) {
+    mysql_stmt_free_result(stmt);
+    mysql_stmt_close(stmt);
+    res.status = 404;
+    res.set_content(R"({"error":"not found"})", "application/json");
+    return;
+  }
+  if (rc == 1) {
+    std::string e = mysql_error(db_);
+    mysql_stmt_free_result(stmt);
+    mysql_stmt_close(stmt);
+    res.status = 500;
+    res.set_content(std::string(R"({"error":"fetch failed: )") + e + "\"}",
+                    "application/json");
+    return;
+  }
+
+  mysql_stmt_free_result(stmt);
+  mysql_stmt_close(stmt);
+
+  std::string json_str(json_buf.data(), json_len);
+  std::vector<DataPoint> pts;
+  try {
+    auto arr = nlohmann::json::parse(json_str);
+    if (arr.is_array()) {
+      for (auto &el : arr) {
+        DataPoint dp;
+        if (el.is_object())
+          dp.extensions = el.value("extensions", nlohmann::json::object());
+        pts.push_back(std::move(dp));
+      }
+    }
+  } catch (...) {
+  }
+
+  TrainingSuitabilityScore score = compute_tss(pts);
+  nlohmann::json out = nlohmann::json::object();
+  for (const auto &kv : score.extensions) {
+    const auto &st = kv.second;
+    out[kv.first] = {{"count", st.count},
+                     {"mean", st.mean},
+                     {"std", st.std},
+                     {"min", st.min},
+                     {"max", st.max}};
+  }
+
+  res.set_header("Access-Control-Allow-Origin", "*");
+  res.set_content(out.dump(), "application/json");
 }

--- a/code/segmentation/engine/src/http/http_handler.hpp
+++ b/code/segmentation/engine/src/http/http_handler.hpp
@@ -32,4 +32,6 @@ private:
   void handleLabMeta(const httplib::Request &req, httplib::Response &res);
   void handleLabResample(const httplib::Request &req, httplib::Response &res);
   void handleSegments(const httplib::Request &req, httplib::Response &res);
+  void handleSegment(const httplib::Request &req, httplib::Response &res);
+  void handleTss(const httplib::Request &req, httplib::Response &res);
 };


### PR DESCRIPTION
## Summary
- add TrainingSuitabilityScore to collect per-extension statistics
- expose `/segment` and `/tss` GET endpoints for segment data and suitability metrics

## Testing
- `cmake ..`
- `make -j2`


------
https://chatgpt.com/codex/tasks/task_e_68bc6a311ba0832db56bb071a9e7d09e