### PR TITLE
Add placeholders for future comparisons and code documentation

### DIFF
--- a/thesistext/thesis.tex
+++ b/thesistext/thesis.tex
@@ -1326,6 +1326,16 @@ with actual training intensity.  Riders were also asked to rate segments on a Li
 average absolute error between TSS ranks and rider preferences was 0.7 points.  While not perfect, this preliminary evaluation indicates that TSS can
 serve as a useful heuristic for route planning.
 
+\section{Comparison with Existing Segment Creation Tools}
+\label{sec:comparison}
+This section contrasts the performance of the segmentation engine developed in this thesis with other public segment creation tools.
+
+\subsection{Qualitative Comparison}
+% TODO: Discuss conceptual differences, feature sets, and user experience between the approaches.
+
+\subsection{Quantitative Comparison}
+% TODO: Present metrics such as segmentation accuracy, processing time, and resource usage to benchmark against existing tools.
+
 \chapter{Results and Conclusions}
 \label{chap:results}
 This project set out to determine whether road suitability for structured cycling training could be quantified using only ride data and open mapping
@@ -1356,6 +1366,11 @@ On the system side, a richer user interface could visualise uncertainty, allow r
 safety over length), and integrate with existing platforms such as Strava or Komoot via APIs.  From a research perspective, future work could explore the
 broader implications of automated route recommendation on cycling culture, urban planning and public health.  Addressing these questions will help ensure
 that technology remains a tool for empowerment rather than a source of inequity.
+
+\section{Deferred Code Implementations}
+\label{sec:unused-code}
+Several modules were built during development but have not yet been integrated into the main pipeline. This section documents these dormant features and outlines how future versions could incorporate them.
+% TODO: Enumerate and describe the unused code segments, explaining their intended roles and integration plans.
 
 \newpage
 \bibliography{references}


### PR DESCRIPTION
## Summary
- add placeholder section for comparing segmentation engine with other segment creation tools
- document areas for unused code segments that may appear in future versions

## Testing
- `latexmk -xelatex -interaction=nonstopmode -halt-on-error thesis.tex` *(fails: The font "GoMono Nerd Font Mono" cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_68be1af0c04c832da45f7516fd75e31a