### PR TITLE
Add option to return segment coordinates from wavelet endpoint

### DIFF
--- a/code/segmentation/engine/src/javascript/signal_lab.html
+++ b/code/segmentation/engine/src/javascript/signal_lab.html
@@ -130,6 +130,19 @@
                       >Persist to DB</span
                     >
                   </label>
+                  <label
+                    style="
+                      margin-left: 8px;
+                      display: inline-flex;
+                      align-items: center;
+                      gap: 4px;
+                    "
+                  >
+                    <input id="wfCoordsToggle" type="checkbox" />
+                    <span style="font-size: 0.9rem; color: var(--fg)"
+                      >Return lat/longs</span
+                    >
+                  </label>
                 </div>
               </div>
 

--- a/code/segmentation/engine/src/javascript/signal_lab.js
+++ b/code/segmentation/engine/src/javascript/signal_lab.js
@@ -982,6 +982,7 @@
     }
 
     const persist = document.getElementById("persistToggle").checked;
+    const includeCoords = document.getElementById("wfCoordsToggle")?.checked;
     const p = getTerrainParams();
     const payload = {
       map: sel,
@@ -989,6 +990,7 @@
       params: { terrain: p },
       persist,
     };
+    if (includeCoords) payload.strava_json = true;
     appendLog(`[wavelet] POST /wavelet fn=terrain map=${sel}`);
 
     const r = await fetch("/wavelet", {
@@ -1018,6 +1020,9 @@
     }
 
     if (window.onWaveletResponse) window.onWaveletResponse(j);
+    if (Array.isArray(j.strava_segments)) {
+      appendLog(`[wavelet] lat/long pairs: ${j.strava_segments.length}`);
+    }
 
     const xWave =
       Array.isArray(j.s_km_uniform) && j.s_km_uniform.length
@@ -1420,11 +1425,15 @@
   });
 
   let segments = [];
+  let stravaSegments = [];
   let segMap = null;
   let currentSegment = -1;
 
   window.onWaveletResponse = function (out) {
     segments = Array.isArray(out.segments) ? out.segments : [];
+    stravaSegments = Array.isArray(out.strava_segments)
+      ? out.strava_segments
+      : [];
     currentSegment = -1;
     const btn = document.querySelector('[data-tab="segments"]');
     if (btn) btn.disabled = segments.length === 0;


### PR DESCRIPTION
## Summary
- add UI checkbox to request segment lat/longs
- send `strava_json` toggle to `/wavelet` and capture returned coordinate pairs

## Testing
- `node --check code/segmentation/engine/src/javascript/signal_lab.js`


------
https://chatgpt.com/codex/tasks/task_e_68bee8e7d990832d983bbc9c08d9065c